### PR TITLE
CLR types that do not map to SQL types will be serialized as JSON

### DIFF
--- a/docs/3.3.1-release-notes.md
+++ b/docs/3.3.1-release-notes.md
@@ -1,2 +1,5 @@
 ### Features
 Support for CluedIn 3.3.0+
+
+### Fixes
++ CLR types that do not map to SQL types will be serialized as JSON

--- a/src/Connector.Snowflake/Connector/SnowflakeConnector.cs
+++ b/src/Connector.Snowflake/Connector/SnowflakeConnector.cs
@@ -326,9 +326,22 @@ namespace CluedIn.Connector.Snowflake.Connector
 
 
 
-            param = (from dataType in data let name = Sanitize(dataType.Key) select new SqlParameter {ParameterName = $"@{name}", Value = dataType.Value ?? ""}).ToList();
+            param = (from dataType in data let name = Sanitize(dataType.Key) select new SqlParameter { ParameterName = $"@{name}", Value = GetDbCompatibleValue(dataType.Value ?? "") }).ToList();
 
             return builder.ToString();
+        }
+
+        private object GetDbCompatibleValue(object o)
+        {
+            try
+            {
+                var t = new SqlParameter() { ParameterName = "dummy", Value = o }.DbType;
+                return o;
+            }
+            catch
+            {
+                return JsonUtility.Serialize(o);
+            }
         }
 
         public override async Task ArchiveContainer(ExecutionContext executionContext, Guid providerDefinitionId, string id)


### PR DESCRIPTION
Applying the same code fix that was applied to the SqlServer connector

https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/pull/27